### PR TITLE
Fix #13: WebSharper: use Owin + upgrade to 3.5

### DIFF
--- a/templates/websharperserverclient/ApplicationName.fsproj
+++ b/templates/websharperserverclient/ApplicationName.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
@@ -6,15 +6,14 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid><%= guid %></ProjectGuid>
     <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{F2A71F9B-5D33-465A-A702-920D77279786}</ProjectTypeGuids>
-    <WebSharperProject>Website</WebSharperProject>
+    <WebSharperProject>Site</WebSharperProject>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+    <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -50,10 +49,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="IntelliFactory.Xml">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\IntelliFactory.Xml.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
@@ -65,95 +60,75 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="HttpMultipartParser">
-      <HintPath>..\packages\WebSharper.Owin.3.4.5.101\lib\net45\HttpMultipartParser.dll</HintPath>
+      <HintPath>..\packages\WebSharper.Owin.3.5.5.112\lib\net45\HttpMultipartParser.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Owin">
-      <HintPath>..\packages\WebSharper.Owin.3.4.5.101\lib\net45\WebSharper.Owin.dll</HintPath>
+      <HintPath>..\packages\WebSharper.Owin.3.5.5.112\lib\net45\WebSharper.Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Collections">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Collections.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Control">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Control.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Control.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Core">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Core.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Core.JavaScript">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Core.JavaScript.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="WebSharper.Html.Client">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Html.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="WebSharper.Html.Server">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Html.Server.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Core.JavaScript.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.InterfaceGenerator">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.InterfaceGenerator.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.InterfaceGenerator.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.JavaScript">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.JavaScript.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.JavaScript.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.JQuery">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.JQuery.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.JQuery.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Main">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Main.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Main.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Sitelets">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Sitelets.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Sitelets.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Testing">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Testing.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.UI.Next">
-      <HintPath>..\packages\WebSharper.UI.Next.3.4.9.157\lib\net40\WebSharper.UI.Next.dll</HintPath>
+      <HintPath>..\packages\WebSharper.UI.Next.3.5.17.191\lib\net40\WebSharper.UI.Next.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.UI.Next.Templating">
-      <HintPath>..\packages\WebSharper.UI.Next.3.4.9.157\lib\net40\WebSharper.UI.Next.Templating.dll</HintPath>
+      <HintPath>..\packages\WebSharper.UI.Next.3.5.17.191\lib\net40\WebSharper.UI.Next.Templating.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Web">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Web.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Web.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Owin">
       <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Owin.Diagnostics">
-      <HintPath>..\packages\Microsoft.Owin.Diagnostics.3.0.1\lib\net45\Microsoft.Owin.Diagnostics.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Owin.FileSystems">
-      <HintPath>..\packages\Microsoft.Owin.FileSystems.3.0.1\lib\net45\Microsoft.Owin.FileSystems.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener">
-      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb">
+      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.3.0.1\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Owin.Hosting">
       <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Owin.StaticFiles">
-      <HintPath>..\packages\Microsoft.Owin.StaticFiles.3.0.1\lib\net45\Microsoft.Owin.StaticFiles.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Owin">
@@ -182,12 +157,12 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
-  <Import Project="..\packages\WebSharper.3.4.9.188\build\WebSharper.targets" Condition="Exists('..\packages\WebSharper.3.4.9.188\build\WebSharper.targets')" />
+  <Import Project="..\packages\WebSharper.3.5.14.215\build\WebSharper.targets" Condition="Exists('..\packages\WebSharper.3.5.14.215\build\WebSharper.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\WebSharper.3.4.9.188\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WebSharper.3.4.9.188\build\WebSharper.targets'))" />
+    <Error Condition="!Exists('..\packages\WebSharper.3.5.14.215\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WebSharper.3.5.14.215\build\WebSharper.targets'))" />
   </Target>
   <ProjectExtensions>
     <VisualStudio>
@@ -195,9 +170,9 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>16151</DevelopmentServerPort>
+          <DevelopmentServerPort>18502</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:16151/</IISUrl>
+          <IISUrl>http://localhost:18502/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/templates/websharperserverclient/Client.fs
+++ b/templates/websharperserverclient/Client.fs
@@ -9,28 +9,18 @@ open WebSharper.UI.Next.Html
 [<JavaScript>]
 module Client =
 
-    let Start input k =
-        async {
-            let! data = Server.DoSomething input
-            return k data
-        }
-        |> Async.Start
-
     let Main () =
-        let input = inputAttr [attr.value ""] []
-        let output = h1 []
+        let rvInput = Var.Create ""
+        let submit = Submitter.CreateOption rvInput.View
+        let vReversed =
+            submit.View.MapAsync(function
+                | None -> async { return "" }
+                | Some input -> Server.DoSomething input
+            )
         div [
-            input
-            buttonAttr [
-                on.click (fun _ _ ->
-                    async {
-                        let! data = Server.DoSomething input.Value
-                        output.Text <- data
-                    }
-                    |> Async.Start
-                )
-            ] [text "Send"]
+            Doc.Input [] rvInput
+            Doc.Button "Send" [] submit.Trigger
             hr []
             h4Attr [attr.``class`` "text-muted"] [text "The server responded:"]
-            divAttr [attr.``class`` "jumbotron"] [output]
+            divAttr [attr.``class`` "jumbotron"] [h1 [textView vReversed]]
         ]

--- a/templates/websharperserverclient/Main.fs
+++ b/templates/websharperserverclient/Main.fs
@@ -26,7 +26,7 @@ module Templating =
         ]
 
     let Main ctx action title body =
-        Content.Doc(
+        Content.Page(
             MainTemplate.Doc(
                 title = title,
                 menubar = MenuBar ctx action,

--- a/templates/websharperserverclient/Startup.fs
+++ b/templates/websharperserverclient/Startup.fs
@@ -5,14 +5,11 @@ open Microsoft.Owin
 open System
 open System.Web
 open Microsoft.Owin.Hosting
-open Microsoft.Owin.StaticFiles
-open Microsoft.Owin.FileSystems
 open WebSharper.Owin
 
 [<Sealed>]
 type Startup() =
     member __.Configuration(builder: IAppBuilder) =
-        let path =  AppDomain.CurrentDomain.SetupInformation.ApplicationBase
-        builder.UseStaticFiles( StaticFileOptions( FileSystem = PhysicalFileSystem(path)))
-               .UseSitelet(path, Site.Main)
+        let path = AppDomain.CurrentDomain.SetupInformation.ApplicationBase
+        builder.UseSitelet(path, Site.Main)
         |> ignore

--- a/templates/websharperserverclient/Web.config
+++ b/templates/websharperserverclient/Web.config
@@ -1,29 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <!-- NOTE: comment the following to run on F# 3.0 -->
+  <!--
+    IMPORTANT NOTE: If you are compiling for F# 3.x with the F# 4.0 compiler
+    (eg. if you are running from Visual Studio 2015), you might hit this
+    runtime error:
+
+      Method not found: 'Void Microsoft.FSharp.Core.CompilationMappingAttribute..ctor(System.String, System.Type[])'.
+
+    This issue is caused by the following bug:
+    https://github.com/Microsoft/visualfsharp/issues/644
+
+    The only way to circumvent this issue is by switching the project to F# 4.0.
+    Don't forget to also set the bindingRedirect below to newVersion="4.4.0.0".
+  -->
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.web>
     <!-- NOTE: remove debug="true" to serve compressed JavaScript -->
     <compilation debug="true" targetFramework="4.0" />
-    <!-- This is only needed for VS Development WebServer. IIS/IIS Express do not use this:-->
-    <httpModules>
+    <!-- Uncomment the following to use WebSharper's HttpModule instead of Owin: -->
+    <!--<httpModules>
       <add name="WebSharper.RemotingModule" type="WebSharper.Web.RpcModule, WebSharper.Web" />
       <add name="WebSharper.Sitelets" type="WebSharper.Sitelets.HttpModule, WebSharper.Sitelets" />
-    </httpModules>
+    </httpModules>-->
   </system.web>
   <system.webServer>
-    <modules>
+    <!-- Uncomment the following to use WebSharper's HttpModule instead of Owin: -->
+    <!--<modules>
       <add name="WebSharper.RemotingModule" type="WebSharper.Web.RpcModule, WebSharper.Web" />
       <add name="WebSharper.Sitelets" type="WebSharper.Sitelets.HttpModule, WebSharper.Sitelets" />
     </modules>
-    <!-- This is only needed for VS Development WebServer (see above). IIS/IIS Express do not use this: -->
-    <validation validateIntegratedModeConfiguration="false" />
+    --><!-- This is only needed for VS Development WebServer (see above). IIS/IIS Express do not use this: --><!--
+    <validation validateIntegratedModeConfiguration="false" />-->
   </system.webServer>
 </configuration>

--- a/templates/websharperserverclient/packages.config
+++ b/templates/websharperserverclient/packages.config
@@ -1,13 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
-    <package id="Microsoft.Owin.Diagnostics" version="3.0.1" targetFramework="net45" />
-    <package id="Microsoft.Owin.FileSystems" version="3.0.1" targetFramework="net45" />
-    <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
+    <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.1" targetFramework="net45" />
     <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
-    <package id="Microsoft.Owin.StaticFiles" version="3.0.1" targetFramework="net45" />
+    <package id="Mono.Cecil" version="0.9.6" targetFramework="net45" />
     <package id="Owin" version="1.0" targetFramework="net45" />
-    <package id="WebSharper" version="3.4.9.188" targetFramework="net45" />
-    <package id="WebSharper.UI.Next" version="3.4.9.157" targetFramework="net45" />
-    <package id="WebSharper.Owin" version="3.4.5.101" targetFramework="net45" />
+    <package id="WebSharper" version="3.5.14.215" targetFramework="net45" />
+    <package id="WebSharper.UI.Next" version="3.5.17.191" targetFramework="net45" />
+    <package id="WebSharper.Owin" version="3.5.5.112" targetFramework="net45" />
 </packages>

--- a/templates/websharperspa/ApplicationName.fsproj
+++ b/templates/websharperspa/ApplicationName.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
@@ -14,8 +14,7 @@
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <NuGetPackageImportStamp></NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -37,7 +36,7 @@
     <Name><%= namespace %></Name>
     <RootNamespace><%= namespace %></RootNamespace>
     <AssemblyName><%= namespace %></AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <WarningLevel>3</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
@@ -48,10 +47,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="IntelliFactory.Xml">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\IntelliFactory.Xml.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
@@ -63,63 +58,55 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WebSharper.Collections">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Collections.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Control">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Control.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Control.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Core">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Core.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Core.JavaScript">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Core.JavaScript.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="WebSharper.Html.Client">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Html.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="WebSharper.Html.Server">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Html.Server.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Core.JavaScript.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.InterfaceGenerator">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.InterfaceGenerator.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.InterfaceGenerator.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.JavaScript">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.JavaScript.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.JavaScript.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.JQuery">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.JQuery.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.JQuery.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Main">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Main.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Main.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Sitelets">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Sitelets.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Sitelets.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Testing">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Testing.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.UI.Next">
-      <HintPath>..\packages\WebSharper.UI.Next.3.4.9.157\lib\net40\WebSharper.UI.Next.dll</HintPath>
+      <HintPath>..\packages\WebSharper.UI.Next.3.5.17.191\lib\net40\WebSharper.UI.Next.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.UI.Next.Templating">
-      <HintPath>..\packages\WebSharper.UI.Next.3.4.9.157\lib\net40\WebSharper.UI.Next.Templating.dll</HintPath>
+      <HintPath>..\packages\WebSharper.UI.Next.3.5.17.191\lib\net40\WebSharper.UI.Next.Templating.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebSharper.Web">
-      <HintPath>..\packages\WebSharper.3.4.9.188\lib\net40\WebSharper.Web.dll</HintPath>
+      <HintPath>..\packages\WebSharper.3.5.14.215\lib\net40\WebSharper.Web.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -144,12 +131,12 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
-  <Import Project="..\packages\WebSharper.3.4.9.188\build\WebSharper.targets" Condition="Exists('..\packages\WebSharper.3.4.9.188\build\WebSharper.targets')" />
+  <Import Project="..\packages\WebSharper.3.5.14.215\build\WebSharper.targets" Condition="Exists('..\packages\WebSharper.3.5.14.215\build\WebSharper.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\WebSharper.3.4.9.188\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WebSharper.3.4.9.188\build\WebSharper.targets'))" />
+    <Error Condition="!Exists('..\packages\WebSharper.3.5.14.215\build\WebSharper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WebSharper.3.5.14.215\build\WebSharper.targets'))" />
   </Target>
   <ProjectExtensions>
     <VisualStudio>
@@ -157,9 +144,9 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>16151</DevelopmentServerPort>
+          <DevelopmentServerPort>19524</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:16151/</IISUrl>
+          <IISUrl>http://localhost:19524/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/templates/websharperspa/Client.fs
+++ b/templates/websharperspa/Client.fs
@@ -23,14 +23,14 @@ module Client =
 
         IndexTemplate.Main.Doc(
             ListContainer = [
-                ListModel.View People |> Doc.Convert (fun name ->
+                People.View.DocSeqCached(fun name ->
                     IndexTemplate.ListItem.Doc(Name = View.Const name)
                 )
             ],
             Name = newName,
             Add = (fun el ev ->
                 People.Add(newName.Value)
-                Var.Set newName ""
+                newName.Value <- ""
             )
         )
         |> Doc.RunById "main"

--- a/templates/websharperspa/packages.config
+++ b/templates/websharperspa/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="WebSharper" version="3.4.9.188" targetFramework="net45" />
-    <package id="WebSharper.UI.Next" version="3.4.9.157" targetFramework="net45" />
+    <package id="WebSharper" version="3.5.14.215" targetFramework="net40" />
+    <package id="WebSharper.UI.Next" version="3.5.17.191" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Note: In order to circumvent the issue discussed in #13 about a runtime error when compiling for F# 3.1 with a 4.0 compiler, I switched the Client-Server project to F# 4.0.
