### PR TITLE
Make the templates compatible for FSharp.AutoComplete with VS2015 tooling

### DIFF
--- a/classlib/ApplicationName.fsproj
+++ b/classlib/ApplicationName.fsproj
@@ -60,7 +60,7 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  <Import Project="$(FSharpTargetsPath)" />
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/console/ApplicationName.fsproj
+++ b/console/ApplicationName.fsproj
@@ -65,7 +65,7 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  <Import Project="$(FSharpTargetsPath)" />
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/fslabbasic/ApplicationName.fsproj
+++ b/fslabbasic/ApplicationName.fsproj
@@ -66,7 +66,7 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  <Import Project="$(FSharpTargetsPath)" />
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/fslabjournal/ApplicationName.fsproj
+++ b/fslabjournal/ApplicationName.fsproj
@@ -69,7 +69,7 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  <Import Project="$(FSharpTargetsPath)" />
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/suave/ApplicationName.fsproj
+++ b/suave/ApplicationName.fsproj
@@ -68,7 +68,7 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  <Import Project="$(FSharpTargetsPath)" />
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/websharperserverclient/ApplicationName.fsproj
+++ b/websharperserverclient/ApplicationName.fsproj
@@ -174,7 +174,7 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  <Import Project="$(FSharpTargetsPath)" />
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <!-- Web targets -->
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/websharperspa/ApplicationName.fsproj
+++ b/websharperspa/ApplicationName.fsproj
@@ -136,7 +136,7 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  <Import Project="$(FSharpTargetsPath)" />
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <!-- Web targets -->
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/windows/ApplicationName.fsproj
+++ b/windows/ApplicationName.fsproj
@@ -93,5 +93,5 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  <Import Project="$(FSharpTargetsPath)" />
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
 </Project>


### PR DESCRIPTION
Hello,

I had problems using the FSharp generator (or generating a .fsproj from VS/Xamarin) and Ionide on my Windows machine (no problem on OS X) both with VS Code and Atom (also with the Vim integration). FSharp.Autocomplete (for some reason, normal msbuild had no problems) could not process .fsproj files when using VS2015 since the targets checked for 2013.

Updated the templates. I **ONLY** tested manually the `Console` and the `Class Library` using `http://yeoman.io/authoring/` instructions. I'm not sure how Yeoman works so maybe there's a better way.

Having fun so far with learning F#, but it seems that VS2015 is not well supported by many F# tooling.

If someone is interested, here's what `FSharp.AutoComplete` says without this condition:

```
{
    "Kind" : "project",
    "Data" : {
        "Project" : "d:\\Development\\fsharp\\sample\\sample.fsproj",
        "Files" : [],
        "Output" : "null",
        "References" : ["C:\\Program Files (x86)\\Reference Assemblies\\Microsoft\\FSharp\\.NETFramework\\v4.0\\4.4.0.0\\FSharp.Core.dll"],
        "Logs" : {
            "d:\\Development\\fsharp\\sample\\sample.fsproj" : "Microsoft.Build.Exceptions.InvalidProjectFileException: The value \"\" of the \"Project\" attribute in element <Import> is invalid. Parameter \"path\" cannot have zero length.  d:\\Development\\fsharp\\sample\\sample.fsproj\r\n   at Microsoft.Build.Shared.ProjectErrorUtilities.ThrowInvalidProject(String errorSubCategoryResourceName, IElementLocation elementLocation, String resourceName, Object[] args)\r\n   at Microsoft.Build.Shared.ProjectErrorUtilities.VerifyThrowInvalidProject(Boolean condition, String errorSubCategoryResourceName, IElementLocation elementLocation, String resourceName, Object arg0, Object arg1, Object arg2, Object arg3)\r\n   at Microsoft.Build.Evaluation.Evaluator`4.ExpandAndLoadImports(String directoryOfImportingFile, String importExpressionEscaped, ProjectImportElement importElement)\r\n   at Microsoft.Build.Evaluation.Evaluator`4.EvaluateImportElement(String directoryOfImportingFile, ProjectImportElement importElement)\r\n   at Microsoft.Build.Evaluation.Evaluator`4.PerformDepthFirstPass(ProjectRootElement currentProjectOrImport)\r\n   at Microsoft.Build.Evaluation.Evaluator`4.Evaluate()\r\n   at Microsoft.Build.Evaluation.Evaluator`4.Evaluate(IEvaluatorData`4 data, ProjectRootElement root, ProjectLoadSettings loadSettings, Int32 maxNodeCount, PropertyDictionary`1 environmentProperties, ILoggingService loggingService, IItemFactory`2 itemFactory, IToolsetProvider toolsetProvider, ProjectRootElementCache projectRootElementCache, BuildEventContext buildEventContext, ProjectInstance projectInstanceIfAnyForDebuggerOnly)\r\n   at Microsoft.Build.Evaluation.Project.ReevaluateIfNecessary(ILoggingService loggingServiceForEvaluation)\r\n   at Microsoft.Build.Evaluation.Project.CreateProjectInstance(ILoggingService loggingServiceForEvaluation, ProjectInstanceSettings settings)\r\n   at Microsoft.FSharp.Compiler.SourceCodeServices.ProjectCrackerTool.Program.projectInstanceFromFullPath@124(FSharpProjectFileInfo this, ProjectCollection engine, String fsprojFullPath)\r\n   at Microsoft.FSharp.Compiler.SourceCodeServices.ProjectCrackerTool.Program.FSharpProjectFileInfo.CrackProjectUsingNewBuildAPI(String fsprojFile)\r\n   at Microsoft.FSharp.Compiler.SourceCodeServices.ProjectCrackerTool.Program.FSharpProjectFileInfo..ctor(String fsprojFileName, FSharpOption`1 properties, FSharpOption`1 enableLogging)\r\n   at Microsoft.FSharp.Compiler.SourceCodeServices.ProjectCrackerTool.Program.getOptions@358(Boolean enableLogging, FSharpList`1 properties, String file)\r\n   at Microsoft.FSharp.Compiler.SourceCodeServices.ProjectCrackerTool.Program.getOptions(String file, Boolean enableLogging, FSharpList`1 properties)\r\n   at Microsoft.FSharp.Compiler.SourceCodeServices.ProjectCrackerTool.Program.main(String[] argv)"
        }
    }
}
```
