### PR TITLE
Blacklist control/punctuation characters for project name

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -237,6 +237,14 @@ var FSharpGenerator = yeoman.generators.Base.extend({
         var done = this.async();
         var prompts = [{
             name: 'applicationName',
+            validate: function(input) {
+                if (input.match(/[\u0000-\u0040]/)) {
+                    return "Invalid module name";
+                }
+                else {
+                    return true;
+                }
+            },
             message: 'What\'s the name of your application?',
             default: this.type
         }];

--- a/app/index.js
+++ b/app/index.js
@@ -238,7 +238,7 @@ var FSharpGenerator = yeoman.generators.Base.extend({
         var prompts = [{
             name: 'applicationName',
             validate: function(input) {
-                if (input.match(/[\u0000-\u0040]/)) {
+                if (input.match(/^[\u0000-\u0040]/) || input.match(/[\u0000-\u002f\u003a-\u0040]/)) {
                     return "Invalid module name";
                 }
                 else {


### PR DESCRIPTION
The validation function ensures that ASCII control and
punctuation (space, hyphen) chars are rejected for the project name
because it is also used as module name in the generated source file.

Fixes #37